### PR TITLE
Fix CLI devices

### DIFF
--- a/configs/cli/td/BH_SAOS502.json
+++ b/configs/cli/td/BH_SAOS502.json
@@ -1,6 +1,6 @@
 {
     "setting_cmd_delay": 0,
-    "setting_default_prompt": "BH_SAOS502",
+    "setting_default_prompt": "bh_saos502",
     "setting_default_user": "frinx",
     "setting_default_passwd": "frinx",
     "configuration save": "",

--- a/configs/cli/td/BH_SAOS513.json
+++ b/configs/cli/td/BH_SAOS513.json
@@ -1,6 +1,6 @@
 {
     "setting_cmd_delay": 0,
-    "setting_default_prompt": "BH_SAOS513",
+    "setting_default_prompt": "bh_saos513",
     "setting_default_user": "frinx",
     "setting_default_passwd": "frinx",
     "configuration save": "",

--- a/configs/cli/td/BH_SAOS555.json
+++ b/configs/cli/td/BH_SAOS555.json
@@ -1,6 +1,6 @@
 {
     "setting_cmd_delay": 0,
-    "setting_default_prompt": "BH_SAOS555",
+    "setting_default_prompt": "bh_saos555",
     "setting_default_user": "frinx",
     "setting_default_passwd": "frinx",
     "configuration save": "",

--- a/configs/cli/td/CSR_SAOS511.json
+++ b/configs/cli/td/CSR_SAOS511.json
@@ -1,6 +1,6 @@
 {
     "setting_cmd_delay": 0,
-    "setting_default_prompt": "CSR_SAOS511",
+    "setting_default_prompt": "csr_saos511",
     "setting_default_user": "frinx",
     "setting_default_passwd": "frinx",
     "configuration save": "",

--- a/configs/cli/td/CSR_SAOS512.json
+++ b/configs/cli/td/CSR_SAOS512.json
@@ -1,6 +1,6 @@
 {
     "setting_cmd_delay": 0,
-    "setting_default_prompt": "CSR_SAOS512",
+    "setting_default_prompt": "csr_saos512",
     "setting_default_user": "frinx",
     "setting_default_passwd": "frinx",
     "configuration save": "",

--- a/configs/cli/td/CSR_SAOS514.json
+++ b/configs/cli/td/CSR_SAOS514.json
@@ -1,6 +1,6 @@
 {
     "setting_cmd_delay": 0,
-    "setting_default_prompt": "CSR_SAOS514",
+    "setting_default_prompt": "csr_saos514",
     "setting_default_user": "frinx",
     "setting_default_passwd": "frinx",
     "configuration save": "",


### PR DESCRIPTION
Some devices had the same expected prompt name as the device name and then the command output was incomplete. This was fixed by putting the prompt to lowercase as the comparison between the prompt and the device is case-sensitive.