### PR TITLE
Improve OSPF configuration

### DIFF
--- a/containerlab/frinx_topo_1/config_c1.partial.txt
+++ b/containerlab/frinx_topo_1/config_c1.partial.txt
@@ -209,21 +209,30 @@ configure {
         ospf 0 {
             admin-state enable
             router-id 1.1.1.1
+            traffic-engineering true
+            traffic-engineering-options {
+                sr-te application-specific-link-attributes
+                advertise-delay true
+            }
             area 0.0.0.0 {
                 interface "system" {
                     admin-state enable
                 }
                 interface "to-c2" {
                     admin-state enable
+                    interface-type point-to-point
                 }
                 interface "to-r1-pe1" {
                     admin-state enable
+                    interface-type point-to-point
                 }
                 interface "to-r2-pe1" {
                     admin-state enable
+                    interface-type point-to-point
                 }
                 interface "to-dc1-pe1" {
                     admin-state enable
+                    interface-type point-to-point
                 }
             }
         }

--- a/containerlab/frinx_topo_1/config_c2.partial.txt
+++ b/containerlab/frinx_topo_1/config_c2.partial.txt
@@ -210,21 +210,30 @@ configure {
         ospf 0 {
             admin-state enable
             router-id 2.2.2.2
+            traffic-engineering true
+            traffic-engineering-options {
+                sr-te application-specific-link-attributes
+                advertise-delay true
+            }
             area 0.0.0.0 {
                 interface "system" {
                     admin-state enable
                 }
                 interface "to-c1" {
                     admin-state enable
+                    interface-type point-to-point
                 }
                 interface "to-r1-pe2" {
                     admin-state enable
+                    interface-type point-to-point
                 }
                 interface "to-r2-pe2" {
                     admin-state enable
+                    interface-type point-to-point
                 }
                 interface "to-dc1-pe1" {
                     admin-state enable
+                    interface-type point-to-point
                 }
             }
         }

--- a/containerlab/frinx_topo_1/config_dc1_pe1.partial.txt
+++ b/containerlab/frinx_topo_1/config_dc1_pe1.partial.txt
@@ -177,15 +177,22 @@ configure {
         ospf 0 {
             admin-state enable
             router-id 7.7.7.7
+            traffic-engineering true
+            traffic-engineering-options {
+                sr-te application-specific-link-attributes
+                advertise-delay true
+            }
             area 0.0.0.0 {
                 interface "system" {
                     admin-state enable
                 }
                 interface "to-c1" {
                     admin-state enable
+                    interface-type point-to-point
                 }
                 interface "to-c2" {
                     admin-state enable
+                    interface-type point-to-point
                 }
             }
         }

--- a/containerlab/frinx_topo_1/config_r1_pe1.partial.txt
+++ b/containerlab/frinx_topo_1/config_r1_pe1.partial.txt
@@ -187,15 +187,26 @@ configure {
         ospf 0 {
             admin-state enable
             router-id 3.3.3.3
+            traffic-engineering true
+            traffic-engineering-options {
+                sr-te application-specific-link-attributes
+                advertise-delay true
+            }
             area 0.0.0.0 {
                 interface "system" {
                     admin-state enable
                 }
                 interface "to-c1" {
                     admin-state enable
+                    interface-type point-to-point
                 }
                 interface "to-r1-pe2" {
                     admin-state enable
+                    interface-type point-to-point
+                }
+                interface "to-bts" {
+                    admin-state enable
+                    passive true
                 }
 
             }

--- a/containerlab/frinx_topo_1/config_r1_pe2.partial.txt
+++ b/containerlab/frinx_topo_1/config_r1_pe2.partial.txt
@@ -177,15 +177,22 @@ configure {
         ospf 0 {
             admin-state enable
             router-id 4.4.4.4
+            traffic-engineering true
+            traffic-engineering-options {
+                sr-te application-specific-link-attributes
+                advertise-delay true
+            }
             area 0.0.0.0 {
                 interface "system" {
                     admin-state enable
                 }
                 interface "to-c2" {
                     admin-state enable
+                    interface-type point-to-point
                 }
                 interface "to-r1-pe1" {
                     admin-state enable
+                    interface-type point-to-point
                 }
 
             }

--- a/containerlab/frinx_topo_1/config_r2_pe1.partial.txt
+++ b/containerlab/frinx_topo_1/config_r2_pe1.partial.txt
@@ -177,15 +177,22 @@ configure {
         ospf 0 {
             admin-state enable
             router-id 5.5.5.5
+            traffic-engineering true
+            traffic-engineering-options {
+                sr-te application-specific-link-attributes
+                advertise-delay true
+            }
             area 0.0.0.0 {
                 interface "system" {
                     admin-state enable
                 }
                 interface "to-c1" {
                     admin-state enable
+                    interface-type point-to-point
                 }
                 interface "to-r2-pe2" {
                     admin-state enable
+                    interface-type point-to-point
                 }
 
             }

--- a/containerlab/frinx_topo_1/config_r2_pe2.partial.txt
+++ b/containerlab/frinx_topo_1/config_r2_pe2.partial.txt
@@ -177,15 +177,22 @@ configure {
         ospf 0 {
             admin-state enable
             router-id 6.6.6.6
+            traffic-engineering true
+            traffic-engineering-options {
+                sr-te application-specific-link-attributes
+                advertise-delay true
+            }
             area 0.0.0.0 {
                 interface "system" {
                     admin-state enable
                 }
                 interface "to-c2" {
                     admin-state enable
+                    interface-type point-to-point
                 }
                 interface "to-r2-pe1" {
                     admin-state enable
+                    interface-type point-to-point
                 }
 
             }


### PR DESCRIPTION
- Added BTS network to OSPF routing topology.
- Specified P2P network type between OSPF routers (avoiding redundant DR election process).